### PR TITLE
Bugfix/commit status

### DIFF
--- a/node/handlers/event.ts
+++ b/node/handlers/event.ts
@@ -196,6 +196,14 @@ const handleNewPullRequest = async (
       repoName,
       prNumber,
       'Beep boop :robot:\n\n Thank you so much for keeping our documentation up-to-date :heart:')
+
+    await gitClient.createCommitStatus(
+      repoName,
+      'Docs in track',
+      'vtex-io/docs-outdated-select',
+      'success',
+      sha
+    )
   }
 
   return true


### PR DESCRIPTION
Fixed bug that would prevent developers from merging PRs because the bot wasn't raising sucessful status and it wasn't possible to reload answer using the comment edit. 